### PR TITLE
Fix await bug in kill

### DIFF
--- a/examples/trio_example.py
+++ b/examples/trio_example.py
@@ -20,6 +20,8 @@ async def main():
                 print(f'Line {i+1}: {line}')
                 print(f'State before:\n{before}\n')
                 print(f'State after:\n{after}\n')
+
+        server.kill()
         nursery.cancel_scope.cancel()
 
 if __name__ == '__main__':

--- a/src/lean_client/trio_server.py
+++ b/src/lean_client/trio_server.py
@@ -89,6 +89,6 @@ class TrioLeanServer:
         else:
             return ''
 
-    async def kill(self):
+    def kill(self):
         """Kill the Lean process."""
-        await self.process.kill()
+        self.process.kill()


### PR DESCRIPTION
This fixes issues with the `kill` method in the trio server:
```
async def kill(self):
         """Kill the Lean process."""
        await self.process.kill()
```
`self.process.kill()` is not `await`-able:
```
TypeError: object NoneType can't be used in 'await' expression
```
So I removed that `await`. Now there is no reason for it to be `async`, so I removed that as well.

Last, I added `server.kill()` to the trio example.  I think it is a good habit to kill processes after you start them.  Here it doesn't matter since you are exiting the application (and exiting trio which I also imagine would kill it), however, it is good to have.  Also it acts as a sort of (weak) test that the bug is fixed.
