### PR TITLE
Fix the example lean file's location of add_comm.

### DIFF
--- a/examples/test.lean
+++ b/examples/test.lean
@@ -5,4 +5,4 @@ begin
 end
 
 example (m n : ℕ) : m + n = n + m :=
-by simp [add_comm]
+by simp only [nat.add_comm]


### PR DESCRIPTION
I'm assuming the intention was for this file to run, not error, but if indeed this was intentional to demonstrate what happens when there's a problem, obviously let me know.

(For now this is part of fixing #16 )