### PR TITLE
Add Widget.

### DIFF
--- a/src/lean_client/commands.py
+++ b/src/lean_client/commands.py
@@ -166,6 +166,13 @@ class InfoSource:
     file: Optional[str] = None
 
 
+@dataclass
+class Widget:
+    line: int
+    column: int
+    id: int
+
+
 GoalState = NewType('GoalState', str)
 
 @dataclass
@@ -178,6 +185,7 @@ class InfoRecord:
     state: Optional[GoalState] = None
     tactic_param_idx: Optional[int] = None
     tactic_params: Optional[List[str]] = None
+    widget: Optional[Widget] = None
 
     @classmethod
     def from_dict(cls, dic):
@@ -187,6 +195,8 @@ class InfoRecord:
             dic['type_'] = dic.pop('type')
         if 'source' in dic:
             dic['source'] = InfoSource(**dic.pop('source'))
+        if 'widget' in dic:
+            dic['widget'] = Widget(**dic.pop('widget'))
         return cls(**dic)
 
 


### PR DESCRIPTION
This seems to be present in lean v3.23.0, and without it,
examples/trio_server.py doesn't run here.

(After this and #17, #16 runs for me.)

I haven't read https://github.com/leanprover-community/lean/blob/master/doc/widget_server.md carefully to be honest, I was just trying to see the example work so far, but this seems correct enough to as I say get it working. I didn't see #14 either until after I put this in, but I guess this closes it.